### PR TITLE
imp: recebe username como input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Hide the browser instead of running headed at Cypress running
 
 Define what browser Cypress must run
 
+### `pr_author_username:
+
+**Required**
+
+Pull Request author username
+
 ## Outputs
 
 ### `result`

--- a/README.md
+++ b/README.md
@@ -5,46 +5,50 @@ This action evaluate Tryber projects with [Cypress](https://www.npmjs.com/packag
 
 ## Inputs
 
-### `npm-start`
+- `npm-start`
 
-**Default: false**
+  **Default: false**
 
-Run npm start and waits to http://localhost:3000 before testing
+  Run npm start and waits to http://localhost:3000 before testing.
 
-### `headless`
+- `headless`
 
-**Default: true**
+  **Default: true**
 
-Hide the browser instead of running headed at Cypress running
+  Hide the browser instead of running headed at Cypress running.
 
-### `browser`
+- `browser`
 
-**Default: "chrome"**
+  **Default: "chrome"**
 
-Define what browser Cypress must run
+  Define what browser Cypress must run.
 
-### `pr_author_username:
+- `pr_author_username`
 
-**Required**
+  **Required**
 
-Pull Request author username
+  Pull Request author username.
 
 ## Outputs
 
-### `result`
+- `result`
 
-Cypress unit tests JSON results in base64 format.
+  Cypress unit tests JSON results in base64 format.
 
 ## Simple usage example
 ```yml
-uses: betrybe/cypress-evaluator-action@v6
+uses: betrybe/cypress-evaluator-action@v7
+with:
+  pr_author_username: ${{ github.event.inputs.pr_author_username }}
 ```
 
 ## How to get result output
 ```yml
 - name: Cypress evaluator
   id: evaluator
-  uses: betrybe/cypress-evaluator-action@v6
+  uses: betrybe/cypress-evaluator-action@v7
+  with:
+    pr_author_username: ${{ github.event.inputs.pr_author_username }}
 - name: Next step
   uses: another-github-action
   with:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   browser:
     description: 'Define what browser Cypress must run'
     default: 'chrome'
+  pr_author_username:
+    description: 'Pull Request author username'
+    required: true
 outputs:
   result:
     description: 'Cypress unit tests JSON results in base64 format.'

--- a/evaluator.js
+++ b/evaluator.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const CORRECT_ANSWER_GRADE = 3;
 const WRONG_ANSWER_GRADE = 1;
 
-const githubUsername = process.env.GITHUB_ACTOR || 'no_actor';
+const githubUsername = process.env.INPUT_PR_AUTHOR_USERNAME || 'no_actor';
 const githubRepositoryName = process.env.GITHUB_REPOSITORY || 'no_repository';
 
 // https://nodejs.org/en/knowledge/command-line/how-to-parse-command-line-arguments/


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.