### PR TITLE
imp: faz build e push da imagem no Dockerhub

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,30 @@
+name: Build and push image to Dockerhub
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Versão do avaliador que você deseja fazer o build"
+        required: true
+        default: "latest"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.12.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: betrybe/cypress-evaluator-action:${{ github.event.inputs.version }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,0 +1,29 @@
+name: Build and push image to Dockerhub on release
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.12.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: betrybe/cypress-evaluator-action:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Conforme [thread](https://betrybe.slack.com/archives/C01Q3PY8LLW/p1638549528400200) foi identificado que alguns projetos passam mais tempo em build por estarem fazendo build do docker toda vez que o avaliador roda. Para melhorar este processo estamos fazendo push da imagem no docker e vamos apenas fazer pull (ao invés de build toda vez). 

Esta PR faz o build e push da imagem para o Dockerhub toda vez que uma nova release do projeto é feita. Também adiciona a opção de fazer isso manualmente via _workflow_dispatch_.