### PR TITLE
imp: usa imagem ao invés do Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Cypress evaluator action for Tryber projects
 
 This action evaluate Tryber projects with [Cypress](https://www.npmjs.com/package/cypress) library.
 
+**WARNING:** the image docker version specified in the `action.yml` must be the same as the last evaluator release version
+
 ## Inputs
 
 - `npm-start`

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: 'Cypress unit tests JSON results in base64 format.'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://betrybe/cypress-evaluator-action:v7'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.headless }}


### PR DESCRIPTION
Conforme discutido na [thread](https://betrybe.slack.com/archives/C01Q3PY8LLW/p1641836637018200?thread_ts=1638549528.400200&cid=C01Q3PY8LLW)  a solução feita fazia com que fosse necessário mudar o arquivo de workflow de todos os projetos vigentes, para evitar isso usamos a imagem direto no avaliador, continua evitando o build (que levava tempo), mas sem precisar de alguma mudança nos projetos.