### PR TITLE
Adiciona a env `CY_CLI` como true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: 'Cypress unit tests JSON results in base64 format.'
 runs:
   using: 'docker'
-  image: 'docker://betrybe/cypress-evaluator-action:v8'
+  image: 'docker://betrybe/cypress-evaluator-action:v8.1'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.headless }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ RUN_NPM_START=$1
 CYPRESS_HEADLESS=$2
 CYPRESS_BROWSER=$3
 
+export CY_CLI=true
+
 npm install
 
 if $RUN_NPM_START ; then


### PR DESCRIPTION
Essa env é utilizada [aqui](https://github.com/betrybe/sd-0x-project-recipes-app-rubric/blob/82a1a0e5a300b75f92fe52a369e1b4f70533d6d4/cypress.config.js#L19) para dizer se o cypress deve considerar ou não o teste `RunAllSpecs.cy.js`.

Contexto, by @EduardoSantosF:
> Na nova versão do cypress não existe o botão "Run all" então eu criei um arquivo que fica responsável por isso. No caso para evitar que esse arquivo rodasse também na command line eu coloquei essa variável de ambiente direto no script e nas config do cypress eu dou um exclude no arquivo de runAll 

Resumindo: esse arquivo RunAll foi criado para facilitar para a pessoa estudante executar todos os testes de uma vez, mas o avaliador não precisa dele, e se ele for executado, cada teste vai acabar sendo executado 2 vezes pelo avaliador.

REF: https://glebbahmutov.com/blog/run-all-specs-cypress-v10/
Thread: https://betrybe.slack.com/archives/C02CLK67CBB/p1661294338786939