### PR TITLE
[LEARN-7568] chore: atualiza imagem do cypress/browsers para usar o nodejs v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+FROM cypress/browsers:node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 COPY entrypoint.sh /entrypoint.sh
 COPY evaluator.js /evaluator.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node16.14.0-chrome99-ff97
+FROM cypress/node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 COPY entrypoint.sh /entrypoint.sh
 COPY evaluator.js /evaluator.js

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This action evaluate Tryber projects with [Cypress](https://www.npmjs.com/packag
 
 ## Simple usage example
 ```yml
-uses: betrybe/cypress-evaluator-action@v7
+uses: betrybe/cypress-evaluator-action@v8.2
 with:
   pr_author_username: ${{ github.event.inputs.pr_author_username }}
 ```
@@ -48,7 +48,7 @@ with:
 ```yml
 - name: Cypress evaluator
   id: evaluator
-  uses: betrybe/cypress-evaluator-action@v7
+  uses: betrybe/cypress-evaluator-action@v8.2
   with:
     pr_author_username: ${{ github.event.inputs.pr_author_username }}
 - name: Next step

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: 'Cypress unit tests JSON results in base64 format.'
 runs:
   using: 'docker'
-  image: 'docker://betrybe/cypress-evaluator-action:v8.1'
+  image: 'docker://betrybe/cypress-evaluator-action:v8.2'
   args:
     - ${{ inputs.npm-start }}
     - ${{ inputs.headless }}


### PR DESCRIPTION
[node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1](https://hub.docker.com/layers/cypress/browsers/node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1/images/sha256-06ba2630c2ef62ba05e01432b6c0925a1d49f73ebb784889f6cc9b849b973146?context=explore)
[v8.2](https://hub.docker.com/layers/betrybe/cypress-evaluator-action/v8.2/images/sha256-379a475e593c09958cf0e724d8c6a65b6f76f96b237b2dc636a462fde388f6bc?context=repo)